### PR TITLE
从react中引入React,Component

### DIFF
--- a/TabBar.js
+++ b/TabBar.js
@@ -67,6 +67,10 @@ export default class TabBar extends Component {
           );
         }
     }
+	//放大按钮
+	_stressPoint (child){
+		return child.props.point ? true: false
+	}
 
     render() {
         let children = this.props.children;
@@ -95,8 +99,8 @@ export default class TabBar extends Component {
                             this.update(i);
                         }}>
                         <View style={styles.center}>
-                            <Image style={styles.navImage} resizeMode='cover' source={imgSrc}/>
-                            <Text style={[styles.navText,{color: color,fontSize: this.props.navFontSize}]}>
+                            <Image style={[styles.navImage, this._stressPoint(child)? styles.navImageChange: '']} resizeMode='cover' source={imgSrc}/>
+                            <Text style={[styles.navText,{color: color,fontSize: this.props.navFontSize}, this._stressPoint(child)? styles.navTextChange: '']}>
                                 {child.props.title}
                             </Text>
                             {this.getBadge(child)}
@@ -198,9 +202,26 @@ const styles = StyleSheet.create({
         height: 24,
         marginBottom: 2,
     },
-    navText: {
-        marginTop: 2,
+	navImageChange: {
+		top: -28,
+		left: -6,
+		width: 56,
+		height: 56,
+		marginBottom: 2,
+		position: 'absolute',
+		borderRadius: 28,
+		borderWidth: 3,
+		borderColor: '#fff',
+		alignSelf: 'center'
+	},
+    navTextChange: {
+        marginTop: 30,
+	    fontSize: 11,
+	    alignSelf: 'center'
     },
+	navText: {
+		marginTop: 2,
+	},
     horizonLine: {
         backgroundColor: '#adadad',
         height: 1,

--- a/TabBar.js
+++ b/TabBar.js
@@ -3,15 +3,15 @@
  */
 'use strict'
 
-import React, {
+import {
     StyleSheet,
-    Component,
     View,
     Image,
     Text,
     TouchableHighlight,
     Dimensions,
 } from 'react-native';
+import React, {Component} from 'react'
 
 import TabBarItem from './TabBarItem';
 

--- a/TabBarItem.js
+++ b/TabBarItem.js
@@ -3,12 +3,12 @@
  */
 'use strict'
 
-import React, {
+import {
     StyleSheet,
-    Component,
     View,
     Text,
 } from 'react-native';
+import React, {Component} from 'react'
 
 export default class TabBarItem extends Component {
 


### PR DESCRIPTION
从react中引入React,Component.避免模拟器提示警告
增加了TabBar.Item的一个配置项:point={true},是否打开放大.具体见下图.

![qq20160521-0 2x](https://cloud.githubusercontent.com/assets/11304944/15449424/fe0fb6ca-1faf-11e6-85bf-135e678e0190.png)
